### PR TITLE
fix: correctly match function identifiers and optional namespaces

### DIFF
--- a/Tera.sublime-syntax
+++ b/Tera.sublime-syntax
@@ -106,7 +106,7 @@ contexts:
         2: entity.name.function.tera
 
   function:
-    - match: '\b\w*(?=::)?(\w+)\s*\('
+    - match: '\b(?:(\w+)::)?(\w+)\s*\('
       captures:
         1: entity.name.namespace.tera
         2: entity.name.function.tera


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![CleanShot 2025-04-16 at 11 02 47](https://github.com/user-attachments/assets/64447310-6f3f-4eb5-a080-366a87fec9b2) | ![CleanShot 2025-04-16 at 11 02 30](https://github.com/user-attachments/assets/d862640a-4794-4e53-9191-1b547edaa3d2) |

```
{% set my_var = macros::some_macro() %}
{% set my_var = global_fn() %}
```