### PR TITLE
fix: use keyword.operator.word for in/and/or/not/is/as operators

### DIFF
--- a/Tera.sublime-syntax
+++ b/Tera.sublime-syntax
@@ -168,7 +168,7 @@ contexts:
     - match: '='
       scope: keyword.operator.assignment.tera
     - match: '\b(in|and|or|not|is|as)\b'
-      scope: keyword.operator.logical.tera
+      scope: keyword.operator.word.tera
     
     - include: number
     - include: boolean


### PR DESCRIPTION
As per https://www.sublimetext.com/docs/scope_naming.html:
> When the operator is a word, such as and, or or not, the following variant is used:
> - keyword.operator.word