### PR TITLE
fix: prefer `punctuation.{section,block}`

### DIFF
--- a/Tera.sublime-syntax
+++ b/Tera.sublime-syntax
@@ -20,24 +20,24 @@ contexts:
     
     - match: '({{)-?'
       captures:
-        1: punctuation.definition.tera
+        1: punctuation.section.group.begin.tera
       push:
         - meta_scope: meta.scope.tera.expression
         - match: '-?(}})'
           captures:
-            1: punctuation.definition.tera
+            1: punctuation.section.group.end.tera
           pop: true
         - include: expression
     
     - match: '({%)-?\s*(if|elif|for|filter|macro|set|set_global|include|import|extends)\s+'
       captures:
-        1: punctuation.definition.tera
+        1: punctuation.section.block.begin.tera
         2: keyword.control.tera
       push:
         - meta_scope: meta.scope.tera.tag
         - match: '-?(%})'
           captures:
-            1: punctuation.definition.tera
+            1: punctuation.section.block.end.tera
           pop: true
         - include: expression
     


### PR DESCRIPTION
This makes more sense to me semantically. It is going to be a bit strange no matter what because of template languages being not usually considered when scope naming, but I think this is best.