### PR TITLE
fix: use `markup.raw.block` instead of `comment.block.tera.raw`

### DIFF
--- a/Tera.sublime-syntax
+++ b/Tera.sublime-syntax
@@ -70,7 +70,7 @@ contexts:
         2: keyword.control.tera
         3: punctuation.definition.tera
       push:
-        - meta_scope: comment.block.tera.raw
+        - meta_scope: markup.raw.block.tera
         - match: '({%)-?\s*(endraw)\s*(%})'
           captures:
             1: punctuation.definition.tera


### PR DESCRIPTION
Using a comment scope for the raw block seems weird (especially it being gray in the Catppuccin theme specifically), so this scope seems more applicable.